### PR TITLE
Make WEOperationResult a generic with regard to result type

### DIFF
--- a/WorkflowEssentials.xcodeproj/project.pbxproj
+++ b/WorkflowEssentials.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		D57205DF1DE23D580071E38A /* WorkflowEssentials.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D57205D51DE23D580071E38A /* WorkflowEssentials.framework */; };
 		D57205E61DE23D580071E38A /* WorkflowEssentials.h in Headers */ = {isa = PBXBuildFile; fileRef = D57205D81DE23D580071E38A /* WorkflowEssentials.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5B49A191DEBD24B001DCD67 /* WEOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D5B49A181DEBD24B001DCD67 /* WEOperationTests.m */; };
+		D5BD72581DF352B700AC8FE8 /* WEOperationResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D5BD72571DF352B700AC8FE8 /* WEOperationResultTests.m */; };
 		D5CDF76A1DE7601E009668ED /* WEOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = D5CDF7681DE7601E009668ED /* WEOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D5CDF76B1DE7601E009668ED /* WEOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = D5CDF7691DE7601E009668ED /* WEOperation.m */; };
 		D5CDF76E1DE769FD009668ED /* WEWorkflow.h in Headers */ = {isa = PBXBuildFile; fileRef = D5CDF76C1DE769FD009668ED /* WEWorkflow.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -38,6 +39,7 @@
 		D57205DE1DE23D580071E38A /* WorkflowEssentialsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WorkflowEssentialsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D57205E51DE23D580071E38A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D5B49A181DEBD24B001DCD67 /* WEOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WEOperationTests.m; sourceTree = "<group>"; };
+		D5BD72571DF352B700AC8FE8 /* WEOperationResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WEOperationResultTests.m; sourceTree = "<group>"; };
 		D5CDF7681DE7601E009668ED /* WEOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WEOperation.h; sourceTree = "<group>"; };
 		D5CDF7691DE7601E009668ED /* WEOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WEOperation.m; sourceTree = "<group>"; };
 		D5CDF76C1DE769FD009668ED /* WEWorkflow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WEWorkflow.h; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				D5B49A181DEBD24B001DCD67 /* WEOperationTests.m */,
+				D5BD72571DF352B700AC8FE8 /* WEOperationResultTests.m */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5BD72581DF352B700AC8FE8 /* WEOperationResultTests.m in Sources */,
 				D5B49A191DEBD24B001DCD67 /* WEOperationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WorkflowEssentials/Operation/WEOperation.h
+++ b/WorkflowEssentials/Operation/WEOperation.h
@@ -9,11 +9,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <WorkflowEssentials/WEOperationResult.h>
 
 @class WEWorkflowContext;
-@class WEOperationResult;
 
-@interface WEOperation : NSObject
+@interface WEOperation<__covariant WEResultType : id<NSCopying> > : NSObject
 
 - (nonnull instancetype)initWithName:(nullable NSString *)name NS_DESIGNATED_INITIALIZER;
 
@@ -67,7 +67,7 @@
  */
 @property (nonatomic, readonly, getter=isCancelled) BOOL cancelled;
 
-@property (nonatomic, readonly, strong, nullable) WEOperationResult *result;
+@property (nonatomic, readonly, strong, nullable) WEOperationResult<WEResultType> *result;
 
 /**
  Starts the operation
@@ -76,7 +76,7 @@
  If an operation is started manually, this method should be called. 
  It updates the state and invokes `start` method, which should be overridden by subclasses to start an actual operation.
  */
-- (void)startWithCompletion:(nullable void (^)(WEOperationResult * _Nullable result))completion completionQueue:(nullable dispatch_queue_t)completionQueue;
+- (void)startWithCompletion:(nullable void (^)(WEOperationResult<WEResultType> * _Nullable result))completion completionQueue:(nullable dispatch_queue_t)completionQueue;
 
 /**
  Marks operation as complete with appropriate result.
@@ -84,6 +84,6 @@
  @discussion a subclass must call this method when an operation is complete.
  It will update the operation state and invoke a callback.
  */
-- (void)completeWithResult:(nullable WEOperationResult *)result;
+- (void)completeWithResult:(nullable WEOperationResult<WEResultType> *)result;
 
 @end

--- a/WorkflowEssentials/Operation/WEOperation.m
+++ b/WorkflowEssentials/Operation/WEOperation.m
@@ -27,7 +27,7 @@ typedef enum
     pthread_mutex_t _mutex;
     WEOperationState _state;
     NSString *_name;
-    WEOperationResult *_result;
+    WEOperationResult<id<NSCopying>> *_result;
     void (^_completion)(WEOperationResult *result);
     dispatch_queue_t _completionQueue;
 }
@@ -100,7 +100,7 @@ _IsOperationInState(__unsafe_unretained WEOperation *operation, WEOperationState
     return result;
 }
 
-- (void)startWithCompletion:(void (^)(WEOperationResult * _Nullable))completion completionQueue:(dispatch_queue_t)completionQueue
+- (void)startWithCompletion:(void (^)(WEOperationResult<id<NSCopying>> * _Nullable))completion completionQueue:(dispatch_queue_t)completionQueue
 {
     if ((completion != nil) ^ (completionQueue != nil)) THROW_INVALID_PARAMS(@{ NSLocalizedDescriptionKey: @"Either completion or completion queue is nil, but not both" });
 

--- a/WorkflowEssentials/Operation/WEOperationResult.h
+++ b/WorkflowEssentials/Operation/WEOperationResult.h
@@ -10,13 +10,13 @@
 
 #import <Foundation/Foundation.h>
 
-@interface WEOperationResult : NSObject
+@interface WEOperationResult<__covariant WEResultType : id<NSCopying> > : NSObject
 
 /**
  Initializes an operation result object as successfully completed with optional result data.
  @param result optional result value of an operation.
  */
-- (nonnull instancetype)initWithResult:(nullable id<NSCopying>)result;
+- (nonnull instancetype)initWithResult:(nullable WEResultType)result;
 /**
  Initializes an operation result object as failed with error.
  @param error an error object representing the failure (required).
@@ -26,7 +26,7 @@
 /** Returns YES if the operation failed, and NO otherwise */
 @property (nonatomic, readonly, getter=isFailed) BOOL failed;
 /** Returns the result object (optional, only when provided for successfully completed operations) */
-@property (nonatomic, readonly, copy, nullable) id<NSCopying> result;
+@property (nonatomic, readonly, copy, nullable) WEResultType result;
 /** Returns an error for a failed operation */
 @property (nonatomic, readonly, strong, nullable) NSError *error;
 

--- a/WorkflowEssentialsTests/Operation/WEOperationResultTests.m
+++ b/WorkflowEssentialsTests/Operation/WEOperationResultTests.m
@@ -1,0 +1,85 @@
+//
+//  WEOperationResultTests.m
+//  Workflow Essentials
+//
+//  Created by Anton Vaneev.
+//  Copyright (c) 2016-present, Anton Vaneev. All rights reserved.
+//
+//  Distributed under BSD license. See LICENSE for details.
+//
+
+#import <XCTest/XCTest.h>
+#import <WorkflowEssentials/WEOperationResult.h>
+
+#import <XCTest/XCTest.h>
+
+@interface FancyCopier : NSObject<NSCopying>
+@property (nonatomic, readonly, nonnull) NSString *string;
+@end
+
+@implementation FancyCopier
+
+- (instancetype)initWithString:(NSString *)string
+{
+    if (self = [super init]) {
+        _string = [string copy];
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    FancyCopier *copy = [[FancyCopier alloc] initWithString:[_string stringByAppendingString:@"-copy"]];
+    return copy;
+}
+
+@end
+
+@interface WEOperationResultTests : XCTestCase
+@end
+
+@implementation WEOperationResultTests
+
+- (void)testSuccessfulResultNoValue
+{
+    WEOperationResult *result = [[WEOperationResult alloc] initWithResult:nil];
+    
+    XCTAssertFalse(result.isFailed);
+    XCTAssertNil(result.result);
+    XCTAssertNil(result.error);
+}
+
+- (void)testSuccessResultCopiesValue
+{
+    FancyCopier *resultData = [[FancyCopier alloc] initWithString:@"result"];
+    WEOperationResult<FancyCopier *> *result = [[WEOperationResult alloc] initWithResult:resultData];
+    XCTAssertFalse(result.isFailed);
+    FancyCopier *returnedData = result.result;
+    XCTAssertNotNil(returnedData);
+    XCTAssertNil(result.error);
+    
+    XCTAssertNotEqual(returnedData, resultData);
+    XCTAssertEqualObjects(result.result, returnedData);
+    XCTAssertEqualObjects(returnedData.string, @"result-copy");
+}
+
+-(void)testFailingResultWithError
+{
+    NSError *error = [NSError errorWithDomain:@"ArbitraryDomain" code:-12345 userInfo:nil];
+    WEOperationResult<FancyCopier *> *result = [[WEOperationResult alloc] initWithError:error];
+    
+    XCTAssertTrue(result.isFailed);
+    XCTAssertEqual(result.error, error);
+}
+
+- (WEOperationResult *)_helperCreateFailureResultWithError:(NSError *)error
+{
+    return [[WEOperationResult alloc] initWithError:error];
+}
+
+- (void)testFailingResultThrowsWithNilError
+{
+    XCTAssertThrows([self _helperCreateFailureResultWithError:nil]);
+}
+
+@end

--- a/WorkflowEssentialsTests/Operation/WEOperationTests.m
+++ b/WorkflowEssentialsTests/Operation/WEOperationTests.m
@@ -14,7 +14,7 @@
 
 static NSString *const WEOperationSimpleSubclassResult = @"WEOperationSimpleSubclass";
 
-@interface WEOperationSimpleSubclass : WEOperation
+@interface WEOperationSimpleSubclass : WEOperation<NSString *>
 @end
 
 @implementation WEOperationSimpleSubclass
@@ -22,7 +22,7 @@ static NSString *const WEOperationSimpleSubclassResult = @"WEOperationSimpleSubc
 - (void)start
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        WEOperationResult *result = [[WEOperationResult alloc] initWithResult:WEOperationSimpleSubclassResult];
+        WEOperationResult<NSString *> *result = [[WEOperationResult alloc] initWithResult:WEOperationSimpleSubclassResult];
         [self completeWithResult:result];
     });
 }
@@ -48,10 +48,10 @@ static NSString *const WEOperationSimpleSubclassResult = @"WEOperationSimpleSubc
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"wait until operation completes"];
     WEOperationSimpleSubclass *operation = [[WEOperationSimpleSubclass alloc] initWithName:@"operationName"];
-    [operation startWithCompletion:^(WEOperationResult * _Nullable result) {
+    [operation startWithCompletion:^(WEOperationResult<NSString *> * _Nullable result) {
         XCTAssert(operation.finished);
         
-        WEOperationResult *operationResult = operation.result;
+        WEOperationResult<NSString *> *operationResult = operation.result;
         XCTAssertNotNil(operationResult);
         XCTAssertEqualObjects(operationResult.result, WEOperationSimpleSubclassResult);
         


### PR DESCRIPTION
Make WEOperationResult a generic with regard to result type, should make it easier to use with specific types of results. Modify operation to be generic too.

Added a few simple tests covering operation result, and modified operation tests to leverage generics.